### PR TITLE
Fix Bourne/bash/etc. shells quoting of "$@"

### DIFF
--- a/commands/gdbfrontend
+++ b/commands/gdbfrontend
@@ -7,4 +7,4 @@ then
     PYCMD=python3
 fi
 
-$PYCMD -m gdbfrontend $@
+$PYCMD -m gdbfrontend "$@"

--- a/gdbfrontend
+++ b/gdbfrontend
@@ -7,4 +7,4 @@ then
     PYCMD=python3
 fi
 
-$PYCMD $(realpath $(dirname "${BASH_SOURCE[0]}"))/run.py $@
+$PYCMD $(realpath $(dirname "${BASH_SOURCE[0]}"))/run.py "$@"

--- a/gdbfrontend-window
+++ b/gdbfrontend-window
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 $(realpath $(dirname "${BASH_SOURCE[0]}"))/run_gui.py $@
+python3 $(realpath $(dirname "${BASH_SOURCE[0]}"))/run_gui.py "$@"


### PR DESCRIPTION
Wrap $@ in double quotes.

See:

https://stackoverflow.com/questions/9994295/what-does-mean-in-a-shell-script

It messed up sys.argv in run.py.