### PR TITLE
Remove faulty package

### DIFF
--- a/build_gdb.sh
+++ b/build_gdb.sh
@@ -114,7 +114,7 @@ case $OS in
 		apt install -q -y gcc g++ make libgmp10 libgmp-dev\
 			expat libexpat1 libexpat1-dev guile-3.0 guile-3.0-dev\
 			lzma lzma-dev libmpfr-dev python3 zlib1g-dev zlib1g\
-			libpython3-dev ubuntu-make texi2html texinfo
+			libpython3-dev texi2html texinfo
 		echo
 		
 		if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Removed ubuntu-make package from dependency installation process. I have tested this script on Ubuntu 20.4 LTS and the package was enabled in it, now I re-run the script on Ubuntu 21.1 and it is gone so got rid of it.