### PR TITLE
Replace 'ping' with 'curl' to check the internet connection in build_gdb.sh

### DIFF
--- a/build_gdb.sh
+++ b/build_gdb.sh
@@ -69,15 +69,16 @@ else	# If couldn't find OS by reading the above two files, install for unknown O
 fi
 
 # Check for internet connection
-which ping > /dev/null
+which curl > /dev/null
 
 # Check for internet connection
 if [ $? -eq 0 ]; then
-	ping -c 2 "www.google.com" > /dev/null
+	curl -I --fail --connect-timeout 30 "www.google.com" > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		printRedStars
 		echo -e "${RED}You may not be connected to the internet."
-		echo -e "${YELLOW}Please check your internet connection${RESET}"
+		echo -e "${YELLOW}Please check your internet connection"
+		echo -e "Note: use \"sudo -E\" to pass proxy settings if you are using http(s) proxy${RESET}"
 		printRedStars
 		abortScript
 	fi


### PR DESCRIPTION
Hi, I’m trying to build GDB from source using _build_gdb.sh_, but I’ve encountered two issues while working behind an HTTP(s) proxy:

1.The script uses the `ping`command to check internet connectivity, which does not respect HTTP proxy settings.
2.The script requires `sudo`, which causes environment variables such as _HTTP_PROXY, HTTPS_PROXY, and http_proxy_ to be lost.

As demonstrated in this MR, perhaps we could use the `curl` command in combination with sudo -E to address these issues.