### PR TITLE
Add commandline option to immediately start with a certain theme

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,6 +37,7 @@ CREDENTIALS = None
 TERMINAL_ID = False
 MAX_ITERATIONS_TO_RET = 1000
 URL_BASE = "/"
+STARTUP_THEME = ""
 
 def init():
     global VERBOSE
@@ -51,6 +52,7 @@ def init():
     global TERMINAL_ID
     global MAX_ITERATIONS_TO_RET
     global URL_BASE
+    global STARTUP_THEME
 
 def setJSON(config_json):
     new_config = json.loads(config_json)

--- a/gdbfrontend.py
+++ b/gdbfrontend.py
@@ -79,3 +79,7 @@ if config.MMAP_PATH:
     http_port = ctypes.c_uint16.from_buffer(mmapBuff, 0)
     
     http_port.value = api.globalvars.httpServer.server_port
+
+if config.STARTUP_THEME and config.STARTUP_THEME != "default":
+    if not plugin.load("theme_" + config.STARTUP_THEME):
+        print("Startup Theme Plugin not found:", config.STARTUP_THEME)

--- a/run.py
+++ b/run.py
@@ -87,8 +87,6 @@ def argHandler_terminalId(name):
     arg_config["TERMINAL_ID"] = terminal_id
 
 def argHandler_startupTheme(name):
-    global open_theme_on_startup
-
     arg_config["STARTUP_THEME"] = name
 
 def argHandler_credentials(_credentials):

--- a/run.py
+++ b/run.py
@@ -86,6 +86,11 @@ def argHandler_terminalId(name):
     api.globalvars.terminal_id = terminal_id
     arg_config["TERMINAL_ID"] = terminal_id
 
+def argHandler_startupTheme(name):
+    global open_theme_on_startup
+
+    arg_config["STARTUP_THEME"] = name
+
 def argHandler_credentials(_credentials):
     global credentials
 
@@ -163,6 +168,7 @@ def argHandler_help():
     print("  --workdir, -w:\t\t\t\tSpecifies working directory.")
     print("  --plugin-dir, -P:\t\t\t\tSpecifies plugins directory.")
     print("  --dontopenuionstartup, -D:\t\t\tAvoids opening UI just after startup.")
+    print("  --startup-theme=NAME, -theme NAME:\t\t\tSpecifies theme name to load on startup. (Default: empty)")
     print("  --verbose, -V:\t\t\t\tEnables verbose output.")
     print("")
 
@@ -222,6 +228,7 @@ args = [
     ["--plugins-dir", "-P", argHandler_pluginsDir, True],
     ["--help", "-h", argHandler_help, False],
     ["--dontopenuionstartup", "-D", argHandler_dontopenuionstartup, False],
+    ["--startup-theme", "-theme", argHandler_startupTheme, True],
     ["--url-base", "-u", argHandler_urlBase, True],
     ["--version", "-v", argHandler_version, False]
 ]


### PR DESCRIPTION
This adds a commandline option --startup-theme to immediately load a theme plugin at startup so you don't need to switch. This is nice for embedded debug where you would restart the device and so gdbfrontend is restarted and the theme you selected is not remembered. With this option you can preselect a theme.

For example `gdbfrontend --startup-theme=metalmajor`
